### PR TITLE
use `Deno.serve` in deno examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,19 +147,18 @@ Similarly, **Mini-Van** can work with Deno as well, in both `van-plate` mode and
 
 Sample code:
 ```typescript
-import { serve } from "https://deno.land/std@0.184.0/http/server.ts"
 import van from "https://deno.land/x/minivan@0.3.9/src/van-plate.js"
 
 const {a, body, li, p, ul} = van.tags
 
-const port = 8080
+const port = 8081
 
 console.log("Testing DOM rendering...")
 // Expecting `<a href="https://vanjs.org/">🍦VanJS</a>` in the console
 console.log(a({href: "https://vanjs.org/"}, "🍦VanJS").render())
 
 console.log(`HTTP webserver running. Access it at: http://localhost:${port}/`)
-await serve(req => new Response(
+Deno.serve({port}, req => new Response(
   van.html(
     body(
       p("Your user-agent is: ", req.headers.get("user-agent") ?? "Unknown"),
@@ -174,7 +173,7 @@ await serve(req => new Response(
     status: 200,
     headers: {"content-type": "text/html; charset=utf-8"},
   },
-), {port})
+))
 ```
 
 ### `mini-van` mode
@@ -184,7 +183,6 @@ Likewise, `mini-van` mode needs a 3rd-party DOM library to provide the `Document
 Sample code:
 
 ```typescript
-import { serve } from "https://deno.land/std@0.184.0/http/server.ts"
 import { DOMParser } from "https://deno.land/x/deno_dom@v0.1.38/deno-dom-wasm.ts"
 import van from "https://deno.land/x/minivan@0.3.9/src/mini-van.js"
 
@@ -201,7 +199,7 @@ const anchorDom = a({href: "https://vanjs.org/"}, "🍦VanJS")
 console.log(anchorDom.outerHTML)
 
 console.log(`HTTP webserver running. Access it at: http://localhost:${port}/`)
-await serve(req => new Response(
+Deno.serve({port}, req => new Response(
   html(
     body(
       p("Your user-agent is: ", req.headers.get("user-agent") ?? "Unknown"),
@@ -216,7 +214,7 @@ await serve(req => new Response(
     status: 200,
     headers: {"content-type": "text/html; charset=utf-8"},
   },
-), {port})
+))
 ```
 
 ## Client-Side: Getting Started


### PR DESCRIPTION
Deno.serve is now stable, so it's probably a good idea to use it in the examples: https://deno.com/blog/v1.35#denoserve-is-now-stable