### PR TITLE
Update van-plate.js

### DIFF
--- a/src/van-plate.js
+++ b/src/van-plate.js
@@ -72,7 +72,7 @@ const tag = (name, ...args) => {
     return typeof plainV === "boolean" ? (plainV ? " " + k : "") :
       // Disable setting attribute for function-valued properties (mostly event handlers),
       // as they're usually not useful for SSR (server-side rendering).
-      protoOf(plainV) !== funcProto ? ` ${k}=${JSON.stringify(escapeAttr(plainV.toString()))}` : ""
+      plainV && protoOf(plainV) !== funcProto ? ` ${k}=${JSON.stringify(escapeAttr(plainV.toString()))}` : ""
   }).join("")
   return {__proto__: elementProto, name, propsStr,
     children: children.flat(Infinity).filter(c => c != null)}


### PR DESCRIPTION
Was getting a weird error with 0.6.2 on server side rendering and this fixes it.

Here's the error:

```bash
file:///home/vanjs-feather/node_modules/mini-van-plate/src/van-plate.js:75
      protoOf(plainV) !== funcProto ? ` ${k}=${JSON.stringify(escapeAttr(plainV.toString()))}` : ""
      ^

TypeError: Cannot convert undefined or null to object
    at getPrototypeOf (<anonymous>)
```

@Tao-VanJS please push asap.
Thanks